### PR TITLE
bg-color hernoemen naar background-color

### DIFF
--- a/startcode/src/test/java/nl/han/ica/icss/parser/Fixtures.java
+++ b/startcode/src/test/java/nl/han/ica/icss/parser/Fixtures.java
@@ -255,7 +255,7 @@ public class Fixtures {
 								.addChild(new ColorLiteral("#124532"))))
 							.addChild((new IfClause())
 									.addChild(new VariableReference("UseLinkColor"))
-									.addChild(new Declaration("bg-color").addChild(new VariableReference("LinkColor")))
+									.addChild(new Declaration("background-color").addChild(new VariableReference("LinkColor")))
 					))
         );
         /*


### PR DESCRIPTION
De fixture van level 3 heeft een typfout, In level3.icss staat wordt in de stylerule van de `p` tag een `background-color` gebruikt. In de fixture wordt voor diezelfde regel een `bg-color` gebruikt. Hierdoor zal de test voor level 3 altijd falen.